### PR TITLE
To Dev: Graphql Events Index

### DIFF
--- a/.github/ISSUE_TEMPLATE/user-story---new-graphql-endpoint.md
+++ b/.github/ISSUE_TEMPLATE/user-story---new-graphql-endpoint.md
@@ -1,0 +1,30 @@
+---
+name: User Story - New GraphQL Endpoint
+about: New user story for GraphQL Endpoint
+title: 'New GraphQL Endpoint: '
+labels: ''
+assignees: fentontaylor
+
+---
+
+/api/v2/graphql-olympians
+
+### Description
+As a user, I 
+
+### Example Query
+```
+query {
+  name {
+    fields
+  }
+}
+
+### Success Response
+```
+
+```
+### Error Response
+```
+
+```

--- a/.github/ISSUE_TEMPLATE/user-story---new-graphql-endpoint.md
+++ b/.github/ISSUE_TEMPLATE/user-story---new-graphql-endpoint.md
@@ -2,7 +2,7 @@
 name: User Story - New GraphQL Endpoint
 about: New user story for GraphQL Endpoint
 title: 'New GraphQL Endpoint: '
-labels: ''
+labels: 'GraphQL Endpoint'
 assignees: fentontaylor
 
 ---
@@ -10,7 +10,7 @@ assignees: fentontaylor
 /api/v2/graphql-olympians
 
 ### Description
-As a user, I 
+As a user, I should be able to use graphql to
 
 ### Example Query
 ```
@@ -19,6 +19,7 @@ query {
     fields
   }
 }
+```
 
 ### Success Response
 ```

--- a/lib/schema/schema.js
+++ b/lib/schema/schema.js
@@ -1,4 +1,7 @@
-const { olympianIndex } = require('../../utils/dbQueries')
+const { 
+  olympianIndex,
+  sportEvents 
+} = require('../../utils/dbQueries')
 const { buildSchema } = require('graphql')
 
 var schema = buildSchema(`
@@ -10,14 +13,23 @@ var schema = buildSchema(`
     total_medals_won: Int
   }
 
+  type Event {
+    sport: String!
+    events: [String]!
+  }
+
   type Query {
     olympians(age: String): [Olympian]
+    events: [Event]!
   }
 `);
 
 var root = {
   olympians: async (args) => {
     return await olympianIndex(args)
+  },
+  events: async () => {
+    return await sportEvents()
   }
 };
 

--- a/routes/api/v1/events.js
+++ b/routes/api/v1/events.js
@@ -7,7 +7,7 @@ const {
 
 router.get('/', (request, response) => {
   sportEvents()
-    .then((result) => response.status(200).send(result))
+    .then((result) => response.status(200).send({ events: result }))
     .catch((error) => response.status(500).send(error))
 });
 

--- a/tests/requests/v2/events.spec.js
+++ b/tests/requests/v2/events.spec.js
@@ -41,7 +41,7 @@ describe('GET /api/v2/graphql-olympians events index', () => {
       }
     }
 
-    const query = 'query{events{events}}'
+    const query = 'query{events{sport events}}'
     const response = await request(app).get(`/api/v2/graphql-olympians?query=${query}`);
 
     expect(response.status).toBe(200);

--- a/tests/requests/v2/events.spec.js
+++ b/tests/requests/v2/events.spec.js
@@ -1,0 +1,50 @@
+const request = require("supertest");
+const app = require('../../../app');
+const DB = require('../../../utils/dbConnect');
+const { destroyAll } = require('../../../utils/dbHelpers');
+
+describe('GET /api/v2/graphql-olympians events index', () => {
+  beforeEach(async () => {
+    await destroyAll();
+  })
+
+  afterEach(async () => {
+    await destroyAll();
+  })
+
+  it('returns every sport and its associated events', async () => {
+    let sport1 = await DB('sports').insert({ sport: 'Athletics' }).returning('*');
+    let sport2 = await DB('sports').insert({ sport: 'Gymnastics' }).returning('*');
+    await DB('events').insert({ event: 'Athletics Women\'s Marathon', sport_id: sport1[0].id });
+    await DB('events').insert({ event: 'Athletics Men\'s Pole Vault', sport_id: sport1[0].id });
+    await DB('events').insert({ event: 'Gymnastics Women\'s Balance Beam', sport_id: sport2[0].id });
+    await DB('events').insert({ event: 'Gymnastics Men\'s Rings', sport_id: sport2[0].id });
+
+    const expected = {
+      data: {
+        events: [
+          {
+            sport: 'Athletics',
+            events: [
+              'Athletics Men\'s Pole Vault',
+              'Athletics Women\'s Marathon'
+            ]
+          },
+          {
+            sport: 'Gymnastics',
+            events: [
+              'Gymnastics Men\'s Rings',
+              'Gymnastics Women\'s Balance Beam'
+            ]
+          }
+        ]
+      }
+    }
+
+    const query = 'query{events{events}}'
+    const response = await request(app).get(`/api/v2/graphql-olympians?query=${query}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(expected);
+  })
+})

--- a/utils/dbQueries.js
+++ b/utils/dbQueries.js
@@ -55,7 +55,7 @@ async function sportEvents() {
         }
       }));
 
-    return { events: result };
+    return result;
   } catch(err) {
     console.log(err)
   }


### PR DESCRIPTION
## Issue Number: #40

### Merge to
- [x] Dev branch
- [ ] Master branch

### Description of Changes
A user can use graphql to get a list of every sport and the associated events. Sport is a String and events is a list of Strings.

### Example Query
```
query {
  events {
    sport
    events
  }
}
```

### Success Response
```
{
  "data": {
    "events":
      [
        {
          "sport": "Archery",
          "events": [
            "Archery Men's Individual",
            "Archery Men's Team",
            "Archery Women's Individual",
            "Archery Women's Team"
          ]
        },
        {
          "sport": "Badminton",
          "events": [
            "Badminton Men's Doubles",
            "Badminton Men's Singles",
            "Badminton Women's Doubles",
            "Badminton Women's Singles",
            "Badminton Mixed Doubles"
          ]
        },
        {...}
      ]
  }
}
```


### Checklist
- [x] Tests written
- [ ] README updated if necessary
- [x] Tested in Postman / Staging 

### Additional Comments
NA