### PR TITLE
Graphql event medalists

### DIFF
--- a/lib/schema/schema.js
+++ b/lib/schema/schema.js
@@ -1,6 +1,7 @@
 const { 
   olympianIndex,
-  sportEvents 
+  sportEvents,
+  eventMedalists 
 } = require('../../utils/dbQueries')
 const { buildSchema } = require('graphql')
 
@@ -18,18 +19,35 @@ var schema = buildSchema(`
     events: [String]!
   }
 
+  type Medalist {
+    name: String!
+    team: String
+    age: Int
+    medal: String
+  }
+
+  type EventMedalist {
+    event: String
+    medalists: [Medalist]
+  }
+
   type Query {
     olympians(age: String): [Olympian]
     events: [Event]!
+    event_medalists(id: ID): EventMedalist
   }
 `);
 
 var root = {
   olympians: async (args) => {
-    return await olympianIndex(args)
+    return await olympianIndex(args);
   },
   events: async () => {
-    return await sportEvents()
+    return await sportEvents();
+  },
+  event_medalists: async (args) => {
+    const eventId = parseInt(args.id)
+    return await eventMedalists(eventId);
   }
 };
 

--- a/tests/requests/v2/eventMedalists.spec.js
+++ b/tests/requests/v2/eventMedalists.spec.js
@@ -10,7 +10,7 @@ const {
   destroyAll
 } = require('../../../utils/dbHelpers');
 
-describe('GET /api/v1/events/:id/medalists', () => {
+describe('GET /api/v2/graphql-olympians event_medalists', () => {
   beforeEach(async () => {
     await destroyAll();
     data = [
@@ -95,29 +95,34 @@ describe('GET /api/v1/events/:id/medalists', () => {
     await createAthleteEvent(data[3], athlete4, event4, olympics4);
 
     let expected = {
-      event: 'Diving Men\'s Platform',
-      medalists: [
-        {
-          name: 'Steven Seagal',
-          team: 'USA',
-          age: 23,
-          medal: 'Gold'
-        },
-        {
-          name: 'Harrison Ford',
-          team: 'USA',
-          age: 30,
-          medal: 'Silver'
-        },
-        {
-          name: 'Mark Hamill',
-          team: 'USA',
-          age: 26,
-          medal: 'Bronze'
+      data: {
+        event_medalists: {
+          event: 'Diving Men\'s Platform',
+          medalists: [
+            {
+              name: 'Steven Seagal',
+              team: 'USA',
+              age: 23,
+              medal: 'Gold'
+            },
+            {
+              name: 'Harrison Ford',
+              team: 'USA',
+              age: 30,
+              medal: 'Silver'
+            },
+            {
+              name: 'Mark Hamill',
+              team: 'USA',
+              age: 26,
+              medal: 'Bronze'
+            }
+          ]
         }
-      ]
+      }
     }
-    let response = await request(app).get(`/api/v1/events/${event.id}/medalists`)
+    let query = `query{event_medalists(id: ${event.id}){event medalists}}`
+    let response = await request(app).get(`/api/v2/graphql-olympians?query=${query}`)
 
     expect(response.status).toBe(200)
     expect(response.body).toEqual(expected)

--- a/tests/requests/v2/eventMedalists.spec.js
+++ b/tests/requests/v2/eventMedalists.spec.js
@@ -121,7 +121,7 @@ describe('GET /api/v2/graphql-olympians event_medalists', () => {
         }
       }
     }
-    let query = `query{event_medalists(id: ${event.id}){event medalists}}`
+    let query = `query{event_medalists(id: ${event.id}){event medalists{name team age medal}}}`
     let response = await request(app).get(`/api/v2/graphql-olympians?query=${query}`)
 
     expect(response.status).toBe(200)


### PR DESCRIPTION
## Issue Number: 

### Merge to
- [x] Dev branch
- [ ] Master branch

### Description of Changes
A user can use graphql to get the medalists for a specific event if they pass in the id of the event

### Example Query
```
query {
  event_medalists(id: 2) {
    event
    medalists {
      name
      team
      age
      medal
    }
  }
}
```

### Success Response
```
{
   "data" : {
      "event_medalists": {
         "event": "Badminton Mixed Doubles",
         "medalists": [
            {
              "name": "Tontowi Ahmad",
              "team": "Indonesia-1",
              "age": 29,
              "medal": "Gold"
            },
            {
              "name": "Chan Peng Soon",
              "team": "Malaysia",
              "age": 28,
              "medal": "Silver"
            }
          ]
      }
   }
}
```

### Checklist
- [ ] Tests written
- [ ] README updated if necessary
- [ ] Tested in Postman / Staging 

### Additional Comments
NA